### PR TITLE
Make Calendar in CalendarList timeZone optional

### DIFF
--- a/app/src/main/java/com/sama/integration/google/calendar/application/Extensions.kt
+++ b/app/src/main/java/com/sama/integration/google/calendar/application/Extensions.kt
@@ -79,7 +79,7 @@ fun GoogleCalendar.toDomain(): Calendar {
     val isOwner = accessRole == "owner"
     val primary = primary ?: false
     return Calendar(
-        ZoneId.of(timeZone),
+        timeZone?.let { ZoneId.of(it) },
         selected ?: primary,
         isOwner
     )

--- a/app/src/main/java/com/sama/integration/google/calendar/domain/CalendarList.kt
+++ b/app/src/main/java/com/sama/integration/google/calendar/domain/CalendarList.kt
@@ -16,7 +16,7 @@ data class CalendarList(
 }
 
 data class Calendar(
-    val timeZone: ZoneId,
+    val timeZone: ZoneId?,
     val selected: Boolean,
     val isOwner: Boolean
 ) {


### PR DESCRIPTION
As per API specification, sometimes it is not set (likely legacy calendars)